### PR TITLE
Pass event in onDateChange

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -125,7 +125,7 @@ class DateInput extends React.Component {
     if (dateString[dateString.length - 1] === '?') {
       onKeyDownQuestionMark(e);
     } else {
-      this.setState({ dateString }, () => onChange(dateString));
+      this.setState({ dateString }, () => onChange(dateString, e));
     }
   }
 

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -179,7 +179,7 @@ class SingleDatePicker extends React.Component {
     if (this.enableScroll) this.enableScroll();
   }
 
-  onChange(dateString) {
+  onChange(dateString, e) {
     const {
       isOutsideRange,
       keepOpenOnDateSelect,
@@ -191,7 +191,7 @@ class SingleDatePicker extends React.Component {
 
     const isValid = newDate && !isOutsideRange(newDate);
     if (isValid) {
-      onDateChange(newDate);
+      onDateChange(newDate, e);
       if (!keepOpenOnDateSelect) {
         onFocusChange({ focused: false });
         onClose({ date: newDate });


### PR DESCRIPTION
To align with our input event passing, it'd nice to have original event passed down to onDateChange Prop.

Can't run any tests, as pretest script checks for linter errors and there are a lot of errors thrown.